### PR TITLE
Adds parameter to pass session options to koa

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adminjs/koa",
-  "version": "2.1.1",
+  "version": "2.0.0",
   "main": "build/index.js",
   "types": "types/index.d.ts",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adminjs/koa",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "build/index.js",
   "types": "types/index.d.ts",
   "private": false,
@@ -25,6 +25,7 @@
     "@types/koa__router": "^8.0.2",
     "@types/koa-bodyparser": "^4.3.0",
     "@types/koa-mount": "^4.0.0",
+    "@types/koa-session": "^5.10.4",
     "@types/koa-static": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adminjs/koa",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "build/index.js",
   "types": "types/index.d.ts",
   "private": false,

--- a/src/buildAuthenticatedRouter.ts
+++ b/src/buildAuthenticatedRouter.ts
@@ -3,27 +3,19 @@ import AdminJS from 'adminjs'
 import Router from '@koa/router'
 import formidableMiddleware from 'koa2-formidable'
 import Application from 'koa'
+import session from 'koa-session'
 import { addAdminJsAuthRoutes, addAdminJsRoutes } from './utils'
 import { DEFAULT_ROOT_PATH } from './constants'
 import { KoaAuthOptions } from './types'
 
-let session
-
-try {
-  session = require('koa-session')
-} catch (e) {
-  // eslint-disable-next-line no-console
-  console.info('koa-session was not loaded')
-}
-
 /**
- * Builds regular koa router.
+ * Builds authenticated koa router.
  * @memberof module:@adminjs/koa
  *
- * @param {AdminJS}    admin      AdminJS instance
- * @param {Application} app        koa application created by `new Koa()`
- * @param {KoaAuthOptions} auth       authentication options
- * @param {Router}      [predefinedRouter] if you have any predefined router
+ * @param {AdminJS}         admin      AdminJS instance
+ * @param {Application}     app        koa application created by `new Koa()`
+ * @param {KoaAuthOptions}  auth       authentication options
+ * @param {Router}          [predefinedRouter] if you have any predefined router
  *    pass it here
  * @param {FormidableOptions} formidableOptions options passed to formidable
  *    module {@link https://github.com/node-formidable/formidable#options}
@@ -36,19 +28,13 @@ const buildAuthenticatedRouter = (
   predefinedRouter?: Router,
   formidableOptions?: Record<string, any>,
 ): Router => {
-  if (!session) {
-    throw new Error(['In order to use authentication, you have to install',
-      'koa-session package',
-    ].join(' '))
-  }
-
   const router = predefinedRouter || new Router({
     prefix: admin.options.rootPath || DEFAULT_ROOT_PATH,
   })
 
   router.use(formidableMiddleware(formidableOptions))
 
-  app.use(session(app))
+  app.use(auth.sessionOptions ? session(auth.sessionOptions, app) : session(app))
 
   addAdminJsAuthRoutes(admin, router, auth)
   addAdminJsRoutes(admin, router, app)

--- a/src/buildRouter.ts
+++ b/src/buildRouter.ts
@@ -9,7 +9,7 @@ import { DEFAULT_ROOT_PATH, INITIALIZED_MESSAGE } from './constants'
  * Builds regular koa router.
  * @memberof module:@adminjs/koa
  *
- * @param {AdminJS}    admin      AdminJS instance
+ * @param {AdminJS}     admin      AdminJS instance
  * @param {Application} app        koa application created by `new Koa()`
  * @param {Router}      [predefinedRouter] if you have any predefined router
  *    pass it here

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,5 +37,5 @@ export type KoaAuthOptions = {
   /**
    * Session options passed to koa-session
    */
-  sessionOptions?: SessionOptions;
+  sessionOptions?: Partial<SessionOptions>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { CurrentAdmin } from 'adminjs'
+import { opts as SessionOptions } from 'koa-session'
 
 /**
  * @memberof module:@adminjs/koa
@@ -32,4 +33,9 @@ export type KoaAuthOptions = {
    * Function returning {@link CurrentAdmin}
    */
   authenticate: KoaAuthenticateFunction;
+
+  /**
+   * Session options passed to koa-session
+   */
+  sessionOptions?: SessionOptions;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,6 +1775,14 @@
   dependencies:
     "@types/koa" "*"
 
+"@types/koa-session@^5.10.4":
+  "integrity" "sha512-Xz9RPq+2raVvw6UN1JzDVL9/s2qr9E5AZOiiQti328HNhEj6IqT5rcssFQPNxCzh9bNG6uqqGMsACr5bdjylXA=="
+  "resolved" "https://registry.npmjs.org/@types/koa-session/-/koa-session-5.10.4.tgz"
+  "version" "5.10.4"
+  dependencies:
+    "@types/cookies" "*"
+    "@types/koa" "*"
+
 "@types/koa-static@^4.0.1":
   "integrity" "sha512-SSpct5fEcAeRkBHa3RiwCIRfDHcD1cZRhwRF///ZfvRt8KhoqRrhK6wpDlYPk/vWHVFE9hPGqh68bhzsHkir4w=="
   "resolved" "https://registry.npmjs.org/@types/koa-static/-/koa-static-4.0.1.tgz"


### PR DESCRIPTION
This PR enables the possibility to pass session options to koa, for requiring secure cookies, et.c.

```typescript
    const adminRouter = buildAuthenticatedRouter(
        adminJS,
        app,
        {
            sessionOptions: {
                secure: secureCookies,
            },
            ...
    }
```

Also included are a couple of bug fixes; exceptions that reached the Koa handler were silently ignored and redirects after post awaited on void.