### PR TITLE
Fix file upload by including files in request.payload.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,7 @@ const addAdminJsRoutes = (admin: AdminJS, router: Router, app: Application): voi
           query: request.query,
           payload: {
             ...(request.body || {}),
+            ...(request.files || {}),
           },
         }
         const html = await controller[route.action](actionRequest, response)


### PR DESCRIPTION
File upload with koa adapter is not working, because koa2-formidable puts uploaded files in ctx.request.files instead of ctx.request.body, therefore they are not included in the library:
![image](https://user-images.githubusercontent.com/35114395/188962109-71d0fd6f-dc01-4bc0-a203-8801b83d49e2.png)

I've fixed it by including ctx.request.files in payload.
Also, I've tested it locally and it works:
![image](https://user-images.githubusercontent.com/35114395/188962636-18308431-4869-4f83-b6b8-a23a83ffa638.png)
